### PR TITLE
fix: fix Winston configuration issue

### DIFF
--- a/libs/log.js
+++ b/libs/log.js
@@ -47,14 +47,17 @@ module.exports.newLogger = (config) => {
                 logInjection: true,
                 service: datadogServiceName,
             });
+
+            const params = new URLSearchParams({
+                "dd-api-key": datadogApiKey,
+                "ddsource": "nodejs",
+                "service": datadogServiceName,
+            })
+            const path = `/api/v2/logs?${params.toString()}`
+
             return new winston.transports.Http({
                 host: 'http-intake.logs.datadoghq.com',
-                path: encodeURIComponent(
-                    '/api/v2/logs?dd-api-key=' +
-                        process.env.DD_API_KEY +
-                        '&ddsource=nodejs&service=' +
-                        datadogServiceName
-                ),
+                path,
                 ssl: true,
             });
         },


### PR DESCRIPTION
Hello, first of all, thanks for creating a great tool.

I noticed that HASH's Datadog integration does not work well.
I don't check Winston internal but I guess `path` for Winston's HTTP transport should not be encoded as URI component.

This PR fixes the issue by stop using `encodeURIComponent()`. 

Here is the evidence this fix works well.

<img width="1316" alt="Screenshot 2023-12-29 at 10 47 25" src="https://github.com/DataDog/HASH/assets/291028/d5d09939-d276-445a-aa3e-fa117be1a462">
